### PR TITLE
title and title-short wrapped in double quotes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -311,11 +311,11 @@ export class EntryCSLAdapter extends Entry {
   }
 
   get title() {
-    return this.data.title;
+    return `"${this.data.title}"`;
   }
 
   get titleShort() {
-    return this.data['title-short'];
+    return `"${this.data['title-short']}"`;
   }
 
   get URL() {


### PR DESCRIPTION
Since Obsidian has introduced Bases, file properties are more important for creating note templates to work literature note. However colons in titles break property values. Adding double quotes before and after title and title-short can avoid this issue